### PR TITLE
Extract and wrap FireFly error messages

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -47,6 +47,8 @@ import {
   FireFlyContractGenerateRequest,
   FireFlyContractAPIRequest,
   FireFlyContractAPIResponse,
+  FireFlyContractInterfaceFilter,
+  FireFlyContractAPIFilter,
 } from './interfaces';
 import { FireFlyWebSocket, FireFlyWebSocketCallback } from './websocket';
 
@@ -104,6 +106,35 @@ export default class FireFly {
     };
   }
 
+  private async getMany<T>(url: string, params?: any, options?: FireFlyGetOptions, root = false) {
+    const http = root ? this.rootHttp : this.http;
+    const response = await http.get<T>(url, mapConfig(options, params));
+    return response.data;
+  }
+
+  private async getOne<T>(url: string, options?: FireFlyGetOptions, params?: any, root = false) {
+    const http = root ? this.rootHttp : this.http;
+    const response = await http.get<T>(url, {
+      ...mapConfig(options, params),
+      validateStatus: (status) => status === 404 || isSuccess(status),
+    });
+    return response.status === 404 ? undefined : response.data;
+  }
+
+  private async createOne<T>(url: string, data: any, options?: FireFlyCreateOptions) {
+    const response = await this.http.post<T>(url, data, mapConfig(options));
+    return response.data;
+  }
+
+  private async replaceOne<T>(url: string, data: any) {
+    const response = await this.http.put<T>(url, data);
+    return response.data;
+  }
+
+  private async deleteOne<T>(url: string) {
+    await this.http.delete<T>(url);
+  }
+
   async getStatus(options?: FireFlyGetOptions): Promise<FireFlyStatusResponse> {
     const response = await this.rootHttp.get<FireFlyStatusResponse>('/status', mapConfig(options));
     return response.data;
@@ -113,22 +144,19 @@ export default class FireFly {
     filter?: FireFlyOrganizationFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyOrganizationResponse[]> {
-    const response = await this.rootHttp.get<FireFlyOrganizationResponse[]>(
+    return this.getMany<FireFlyOrganizationResponse[]>(
       '/network/organizations',
-      mapConfig(options, filter),
+      filter,
+      options,
+      true,
     );
-    return response.data;
   }
 
   async getNodes(
     filter?: FireFlyNodeFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyNodeResponse[]> {
-    const response = await this.rootHttp.get<FireFlyNodeResponse[]>(
-      '/network/nodes',
-      mapConfig(options, filter),
-    );
-    return response.data;
+    return this.getMany<FireFlyNodeResponse[]>('/network/nodes', filter, options, true);
   }
 
   async getVerifiers(
@@ -137,22 +165,19 @@ export default class FireFly {
     options?: FireFlyGetOptions,
   ): Promise<FireFlyVerifierResponse[]> {
     namespace = namespace ?? this.options.namespace;
-    const response = await this.rootHttp.get<FireFlyVerifierResponse[]>(
+    return this.getMany<FireFlyVerifierResponse[]>(
       `/namespaces/${namespace}/verifiers`,
-      mapConfig(options, filter),
+      filter,
+      options,
+      true,
     );
-    return response.data;
   }
 
   async getDatatypes(
     filter?: FireFlyDatatypeFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyDatatypeResponse[]> {
-    const response = await this.http.get<FireFlyDatatypeResponse[]>(
-      '/datatypes',
-      mapConfig(options, filter),
-    );
-    return response.data;
+    return this.getMany<FireFlyDatatypeResponse[]>('/datatypes', filter, options);
   }
 
   async getDatatype(
@@ -160,23 +185,14 @@ export default class FireFly {
     version: string,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyDatatypeResponse | undefined> {
-    const response = await this.http.get<FireFlyDatatypeResponse>(`/datatypes/${name}/${version}`, {
-      ...mapConfig(options),
-      validateStatus: (status) => status === 404 || isSuccess(status),
-    });
-    return response.status === 404 ? undefined : response.data;
+    return this.getOne<FireFlyDatatypeResponse>(`/datatypes/${name}/${version}`, options);
   }
 
   async createDatatype(
     req: FireFlyDatatypeRequest,
     options?: FireFlyCreateOptions,
   ): Promise<FireFlyDatatypeResponse> {
-    const response = await this.http.post<FireFlyDatatypeResponse>(
-      '/datatypes',
-      req,
-      mapConfig(options),
-    );
-    return response.data;
+    return this.createOne('/datatypes', req, options);
   }
 
   async getOrCreateDatatype(
@@ -197,35 +213,26 @@ export default class FireFly {
       }
       return existing;
     }
-    const created = await this.createDatatype(req, { ...mapConfig(options), confirm: true });
-    return created;
+    return this.createDatatype(req, { ...mapConfig(options), confirm: true });
   }
 
   async getSubscriptions(
     filter?: FireFlySubscriptionFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlySubscriptionResponse[]> {
-    const response = await this.http.get<FireFlySubscriptionResponse[]>(
-      '/subscriptions',
-      mapConfig(options, filter),
-    );
-    return response.data;
+    return this.getMany<FireFlySubscriptionResponse[]>('/subscriptions', filter, options);
   }
 
-  async createOrUpdateSubscription(
-    sub: FireFlySubscriptionRequest,
-  ): Promise<FireFlySubscriptionResponse> {
-    const response = await this.http.put<FireFlySubscriptionResponse>('/subscriptions', sub);
-    return response.data;
+  async replaceSubscription(sub: FireFlySubscriptionRequest): Promise<FireFlySubscriptionResponse> {
+    return this.replaceOne<FireFlySubscriptionResponse>('/subscriptions', sub);
   }
 
   async deleteSubscription(subId: string) {
-    await this.http.delete(`/subscriptions/${subId}`);
+    await this.deleteOne(`/subscriptions/${subId}`);
   }
 
-  async getData(id: string, options?: FireFlyGetOptions): Promise<FireFlyDataResponse> {
-    const response = await this.http.get<FireFlyDataResponse>(`/data/${id}`, mapConfig(options));
-    return response.data;
+  async getData(id: string, options?: FireFlyGetOptions): Promise<FireFlyDataResponse | undefined> {
+    return this.getOne<FireFlyDataResponse>(`/data/${id}`, options);
   }
 
   async getDataBlob(id: string, options?: FireFlyGetOptions): Promise<Stream> {
@@ -256,42 +263,28 @@ export default class FireFly {
     filter?: FireFlyBatchFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyBatchResponse[]> {
-    const response = await this.http.get<FireFlyBatchResponse[]>(
-      `/batches`,
-      mapConfig(options, filter),
-    );
-    return response.data;
+    return this.getMany<FireFlyBatchResponse[]>(`/batches`, filter, options);
   }
 
   async getMessages(
     filter?: FireFlyMessageFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyMessageResponse[]> {
-    const response = await this.http.get<FireFlyMessageResponse[]>(
-      `/messages`,
-      mapConfig(options, filter),
-    );
-    return response.data;
+    return this.getMany<FireFlyMessageResponse[]>(`/messages`, filter, options);
   }
 
-  async getMessage(id: string, options?: FireFlyGetOptions): Promise<FireFlyMessageResponse> {
-    const response = await this.http.get<FireFlyMessageResponse>(
-      `/messages/${id}`,
-      mapConfig(options),
-    );
-    return response.data;
+  async getMessage(
+    id: string,
+    options?: FireFlyGetOptions,
+  ): Promise<FireFlyMessageResponse | undefined> {
+    return this.getOne<FireFlyMessageResponse>(`/messages/${id}`, options);
   }
 
   async sendBroadcast(
     message: FireFlyBroadcastMessageRequest,
     options?: FireFlyCreateOptions,
   ): Promise<FireFlyMessageResponse> {
-    const response = await this.http.post<FireFlyMessageResponse>(
-      '/messages/broadcast',
-      message,
-      mapConfig(options),
-    );
-    return response.data;
+    return this.createOne<FireFlyMessageResponse>('/messages/broadcast', message, options);
   }
 
   async sendPrivateMessage(
@@ -299,129 +292,87 @@ export default class FireFly {
     options?: FireFlyPrivateSendOptions,
   ): Promise<FireFlyMessageResponse> {
     const url = options?.requestReply ? '/messages/requestreply' : '/messages/private';
-    const response = await this.http.post<FireFlyMessageResponse>(url, message, mapConfig(options));
-    return response.data;
+    return this.createOne<FireFlyMessageResponse>(url, message, options);
   }
 
   async createTokenPool(
     pool: FireFlyTokenPoolRequest,
     options?: FireFlyCreateOptions,
   ): Promise<FireFlyTokenPoolResponse> {
-    const response = await this.http.post<FireFlyTokenPoolResponse>(
-      '/tokens/pools',
-      pool,
-      mapConfig(options),
-    );
-    return response.data;
+    return this.createOne<FireFlyTokenPoolResponse>('/tokens/pools', pool, options);
   }
 
   async getTokenPools(
     filter?: FireFlyTokenPoolFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyTokenPoolResponse[]> {
-    const response = await this.http.get<FireFlyTokenPoolResponse[]>(
-      `/tokens/pools`,
-      mapConfig(options, filter),
-    );
-    return response.data;
+    return this.getMany<FireFlyTokenPoolResponse[]>(`/tokens/pools`, filter, options);
   }
 
   async getTokenPool(
     nameOrId: string,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyTokenPoolResponse | undefined> {
-    const response = await this.http.get<FireFlyTokenPoolResponse>(`/tokens/pools/${nameOrId}`, {
-      ...mapConfig(options),
-      validateStatus: (status) => status === 404 || isSuccess(status),
-    });
-    return response.status === 404 ? undefined : response.data;
+    return this.getOne<FireFlyTokenPoolResponse>(`/tokens/pools/${nameOrId}`, options);
   }
 
   async mintTokens(transfer: FireFlyTokenMintRequest, options?: FireFlyCreateOptions) {
-    const response = await this.http.post<FireFlyTokenTransferResponse>(
-      '/tokens/mint',
-      transfer,
-      mapConfig(options),
-    );
-    return response.data;
+    return this.createOne<FireFlyTokenTransferResponse>('/tokens/mint', transfer, options);
   }
 
   async transferTokens(
     transfer: FireFlyTokenTransferRequest,
     options?: FireFlyCreateOptions,
   ): Promise<FireFlyTokenTransferResponse> {
-    const response = await this.http.post<FireFlyTokenTransferResponse>(
-      '/tokens/transfers',
-      transfer,
-      mapConfig(options),
-    );
-    return response.data;
+    return this.createOne<FireFlyTokenTransferResponse>('/tokens/transfers', transfer, options);
   }
 
   async burnTokens(
     transfer: FireFlyTokenBurnRequest,
     options?: FireFlyCreateOptions,
   ): Promise<FireFlyTokenTransferResponse> {
-    const response = await this.http.post<FireFlyTokenTransferResponse>(
-      '/tokens/burn',
-      transfer,
-      mapConfig(options),
-    );
-    return response.data;
+    return this.createOne<FireFlyTokenTransferResponse>('/tokens/burn', transfer, options);
   }
 
   async getTokenTransfer(
     id: string,
     options?: FireFlyGetOptions,
-  ): Promise<FireFlyTokenTransferResponse> {
-    const response = await this.http.get<FireFlyTokenTransferResponse>(
-      `/tokens/transfers/${id}`,
-      mapConfig(options),
-    );
-    return response.data;
+  ): Promise<FireFlyTokenTransferResponse | undefined> {
+    return this.getOne<FireFlyTokenTransferResponse>(`/tokens/transfers/${id}`, options);
   }
 
   async getTokenBalances(
     filter?: FireFlyTokenBalanceFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyTokenBalanceResponse> {
-    const response = await this.http.get<FireFlyTokenBalanceResponse>(
-      '/tokens/balances',
-      mapConfig(options, filter),
-    );
-    return response.data;
+    return this.getMany<FireFlyTokenBalanceResponse>('/tokens/balances', filter, options);
   }
 
   async generateContractInterface(
     request: FireFlyContractGenerateRequest,
   ): Promise<FireFlyContractInterfaceRequest> {
-    const response = await this.http.post<FireFlyContractInterfaceRequest>(
+    return this.createOne<FireFlyContractInterfaceRequest>(
       '/contracts/interfaces/generate',
       request,
     );
-    return response.data;
   }
 
   async createContractInterface(
     ffi: FireFlyContractInterfaceRequest,
     options?: FireFlyCreateOptions,
   ): Promise<FireFlyContractInterfaceResponse> {
-    const response = await this.http.post<FireFlyContractInterfaceResponse>(
-      '/contracts/interfaces',
-      ffi,
-      mapConfig(options),
-    );
-    return response.data;
+    return this.createOne<FireFlyContractInterfaceResponse>('/contracts/interfaces', ffi, options);
   }
 
   async getContractInterfaces(
+    filter?: FireFlyContractInterfaceFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyContractInterfaceResponse[]> {
-    const response = await this.http.get<FireFlyContractInterfaceResponse[]>(
+    return this.getMany<FireFlyContractInterfaceResponse[]>(
       '/contracts/interfaces',
-      mapConfig(options),
+      filter,
+      options,
     );
-    return response.data;
   }
 
   async getContractInterface(
@@ -429,65 +380,48 @@ export default class FireFly {
     fetchchildren?: boolean,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyContractInterfaceResponse | undefined> {
-    const response = await this.http.get<FireFlyContractInterfaceResponse>(
-      `/contracts/interfaces/${id}`,
-      {
-        ...mapConfig(options, { fetchchildren }),
-        validateStatus: (status) => status === 404 || isSuccess(status),
-      },
-    );
-    return response.status === 404 ? undefined : response.data;
+    return this.getOne<FireFlyContractInterfaceResponse>(`/contracts/interfaces/${id}`, options, {
+      fetchchildren,
+    });
   }
 
   async createContractAPI(
     api: FireFlyContractAPIRequest,
     options?: FireFlyCreateOptions,
   ): Promise<FireFlyContractAPIResponse> {
-    const response = await this.http.post<FireFlyContractAPIResponse>(
-      '/apis',
-      api,
-      mapConfig(options),
-    );
-    return response.data;
+    return this.createOne<FireFlyContractAPIResponse>('/apis', api, options);
   }
 
-  async getContractAPIs(options?: FireFlyGetOptions): Promise<FireFlyContractAPIResponse[]> {
-    const response = await this.http.get<FireFlyContractAPIResponse[]>('/apis', mapConfig(options));
-    return response.data;
+  async getContractAPIs(
+    filter?: FireFlyContractAPIFilter,
+    options?: FireFlyGetOptions,
+  ): Promise<FireFlyContractAPIResponse[]> {
+    return this.getMany<FireFlyContractAPIResponse[]>('/apis', filter, options);
   }
 
   async getContractAPI(
     name: string,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyContractAPIResponse | undefined> {
-    const response = await this.http.get<FireFlyContractAPIResponse>(`/apis/${name}`, {
-      ...mapConfig(options),
-      validateStatus: (status) => status === 404 || isSuccess(status),
-    });
-    return response.status === 404 ? undefined : response.data;
+    return this.getOne<FireFlyContractAPIResponse>(`/apis/${name}`, options);
   }
 
   async createContractListener(
     listener: FireFlyContractListenerRequest,
     options?: FireFlyCreateOptions,
   ): Promise<FireFlyContractListenerResponse> {
-    const response = await this.http.post<FireFlyContractListenerResponse>(
+    return this.createOne<FireFlyContractListenerResponse>(
       '/contracts/listeners',
       listener,
-      mapConfig(options),
+      options,
     );
-    return response.data;
   }
 
   async getContractListeners(
     filter?: FireFlyContractListenerFilter,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyContractListenerResponse[]> {
-    const response = await this.http.get<FireFlyContractListenerResponse[]>(
-      '/contracts/listeners',
-      mapConfig(options, filter),
-    );
-    return response.data;
+    return this.getMany<FireFlyContractListenerResponse[]>('/contracts/listeners', filter, options);
   }
 
   async getContractAPIListeners(
@@ -495,11 +429,11 @@ export default class FireFly {
     eventPath: string,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyContractListenerResponse[]> {
-    const response = await this.http.get<FireFlyContractListenerResponse[]>(
+    return this.getMany<FireFlyContractListenerResponse[]>(
       `/apis/${apiName}/listeners/${eventPath}`,
-      mapConfig(options),
+      {},
+      options,
     );
-    return response.data;
   }
 
   async createContractAPIListener(
@@ -508,23 +442,18 @@ export default class FireFly {
     listener: FireFlyContractListenerRequest,
     options?: FireFlyCreateOptions,
   ) {
-    const response = await this.http.post<FireFlyContractListenerResponse>(
+    return this.createOne<FireFlyContractListenerResponse>(
       `/apis/${apiName}/listeners/${eventPath}`,
       listener,
-      mapConfig(options),
+      options,
     );
-    return response.data;
   }
 
   async getTransaction(
     id: string,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyTransactionResponse | undefined> {
-    const response = await this.http.get<FireFlyTransactionResponse>(`/transactions/${id}`, {
-      ...mapConfig(options),
-      validateStatus: (status) => status === 404 || isSuccess(status),
-    });
-    return response.status === 404 ? undefined : response.data;
+    return this.getOne<FireFlyTransactionResponse>(`/transactions/${id}`, options);
   }
 
   listen(

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -213,6 +213,9 @@ export type FireFlyTransactionResponse = Required<
 
 // Contracts
 
+export type FireFlyContractInterfaceFilter =
+  operations['getContractInterfaces']['parameters']['query'];
+export type FireFlyContractAPIFilter = operations['getContractAPIs']['parameters']['query'];
 export type FireFlyContractListenerFilter =
   operations['getContractListeners']['parameters']['query'];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/firefly-sdk",
-      "version": "0.1.0-alpha.8",
+      "version": "0.1.0-alpha.9",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "Client SDK for Hyperledger FireFly",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "declaration": true,
     "outDir": "./dist"
   },
-  "exclude": ["examples", "dist"]
+  "include": ["lib/**/*"]
 }


### PR DESCRIPTION
If an error reply from FireFly has the form `{"error": "Something bad"}`, extract only the error message from the JSON and throw it as a new `FireFlyError` type. If the error message cannot be parsed, use the whole body text.

See https://github.com/hyperledger/firefly/issues/753