### PR TITLE
Add eberger727 as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # firefly-ui maintainers
-* @peterbroadhurst @awrichar @nguyer
+* @peterbroadhurst @awrichar @nguyer @eberger727


### PR DESCRIPTION
@eberger727 is listed as a maintainer already, but somehow missed getting added to CODEOWNERS so he can review PRs.