### PR TITLE
getStatus is now namespaced

### DIFF
--- a/lib/firefly.ts
+++ b/lib/firefly.ts
@@ -77,7 +77,7 @@ export default class FireFly extends HttpBase {
   private queue = Promise.resolve();
 
   async getStatus(options?: FireFlyGetOptions): Promise<FireFlyStatusResponse> {
-    const response = await this.rootHttp.get<FireFlyStatusResponse>('/status', mapConfig(options));
+    const response = await this.http.get<FireFlyStatusResponse>('/status', mapConfig(options));
     return response.data;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Client SDK for Hyperledger FireFly",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
 - Change getStatus to use the `http` axios instance.

The `getStatus()` method was previously using the `rootHttp` instance instead of `http`. This means `getStatus` was always returning status for the default namespace, instead of the namespace provided to the firefly client.