### PR TITLE
Add request option support where missing

### DIFF
--- a/lib/firefly.ts
+++ b/lib/firefly.ts
@@ -203,6 +203,7 @@ export default class FireFly extends HttpBase {
     blob: string | Buffer | Readable,
     blobOptions?: FormData.AppendOptions,
     dataOptions?: FireFlyDataBlobRequest,
+    options?: FireFlyCreateOptions,
   ): Promise<FireFlyDataResponse> {
     dataOptions = { ...FireFlyDataBlobRequestDefaults, ...dataOptions };
     const formData = new FormData();
@@ -213,9 +214,12 @@ export default class FireFly extends HttpBase {
       }
     }
     formData.append('file', blob, blobOptions);
+    const requestOptions = mapConfig(options);
     const response = await this.wrapError(
       this.http.post<FireFlyDataResponse>('/data', formData, {
+        ...requestOptions,
         headers: {
+          ...requestOptions.headers,
           ...formData.getHeaders(),
           'Content-Length': formData.getLengthSync(),
         },
@@ -341,10 +345,12 @@ export default class FireFly extends HttpBase {
 
   generateContractInterface(
     request: FireFlyContractGenerateRequest,
+    options?: FireFlyCreateOptions,
   ): Promise<FireFlyContractInterfaceRequest> {
     return this.createOne<FireFlyContractInterfaceRequest>(
       '/contracts/interfaces/generate',
       request,
+      options,
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.1.11",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/firefly-sdk",
-      "version": "1.1.11",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Client SDK for Hyperledger FireFly",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- generateContractInterface
- uploadDataBlob

Enables SDK clients to pass through request options to the underlying axios instance. Supported in _most_ SDK commands already - these were missing.

Signed-off-by: Chris Bygrave <chris.bygrave@kaleido.io>