### PR TITLE
fixing get status method

### DIFF
--- a/lib/firefly.ts
+++ b/lib/firefly.ts
@@ -78,7 +78,11 @@ import HttpBase, { mapConfig } from './http';
 export default class FireFly extends HttpBase {
   private queue = Promise.resolve();
 
-  async getStatus(options?: FireFlyGetOptions): Promise<FireFlyStatusResponse> {
+  async getStatus(options?: FireFlyGetOptions): Promise<FireFlyStatusResponse | undefined> {
+    return this.getOne<FireFlyStatusResponse>(`/status`, options);
+  }
+
+  async getDefaultNamespaceStatus(options?: FireFlyGetOptions): Promise<FireFlyStatusResponse> {
     const response = await this.http.get<FireFlyStatusResponse>('/status', mapConfig(options));
     return response.data;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "description": "Client SDK for Hyperledger FireFly",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Signed-off-by: Chengxuan Xing <chengxuan.xing@kaleido.io>

The current `getStatus` method calls the wrong global `/status` API which returns the status of the default namespace rather than the one configured when Firefly SDK is initialised.

I think this is a bug based on the convention that all methods should be under the namespace scope.

I also added a  `getDefaultNamespaceStatus` as I don't know an API that returns information about whether a namespace is the default namespace.

