### PR TITLE
Support for passing headers through to ws connect calls

### DIFF
--- a/lib/firefly.ts
+++ b/lib/firefly.ts
@@ -549,6 +549,7 @@ export default class FireFly extends HttpBase {
   listen(
     subscriptions: string | string[] | FireFlySubscriptionBase,
     callback: FireFlyWebSocketCallback,
+    headers?: Record<string, string>,
   ): FireFlyWebSocket {
     const options: FireFlyWebSocketOptions = {
       host: this.options.websocket.host,
@@ -559,6 +560,7 @@ export default class FireFly extends HttpBase {
       autoack: false,
       reconnectDelay: this.options.websocket.reconnectDelay,
       heartbeatInterval: this.options.websocket.heartbeatInterval,
+      headers: headers,
     };
 
     const handler: FireFlyWebSocketCallback = (socket, event) => {

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -61,6 +61,7 @@ export interface FireFlyWebSocketOptions {
   autoack: boolean;
   reconnectDelay: number;
   heartbeatInterval: number;
+  headers?: Record<string, string>;
 }
 
 // Namespace

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -59,6 +59,7 @@ export class FireFlyWebSocket {
     const socket = (this.socket = new WebSocket(url, {
       auth,
       handshakeTimeout: this.options.heartbeatInterval,
+      headers: this.options.headers,
     }));
     this.closed = false;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.2.1",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/firefly-sdk",
-      "version": "1.2.1",
+      "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Client SDK for Hyperledger FireFly",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This is needed to allow firefly-sdk-nodejs to work against an authenticated web socket server.

Signed-off-by: Chris Bygrave <chris.bygrave@kaleido.io>