### PR TITLE
Support non-reconnecting websockets

### DIFF
--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -148,7 +148,11 @@ export class FireFlyWebSocket {
     if (!this.reconnectTimer) {
       this.close();
       this.logger.error(`Websocket closed: ${msg}`);
-      this.reconnectTimer = setTimeout(() => this.connect(), this.options.reconnectDelay);
+      if (this.options.reconnectDelay === -1) {
+        // do not attempt to reconnect
+      } else {
+        this.reconnectTimer = setTimeout(() => this.connect(), this.options.reconnectDelay);
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/firefly-sdk",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Client SDK for Hyperledger FireFly",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- treat a recconectDelay of -1 as meaning do not attempt to reconnect
- reconnecting is not always desirable - for example when using firefly-sdk as a websocket proxy

Signed-off-by: Chris Bygrave <chris.bygrave@kaleido.io>