### PR TITLE
Allow custom app logic to trigger when a websocket connects/reconnects

### DIFF
--- a/lib/firefly.ts
+++ b/lib/firefly.ts
@@ -79,6 +79,7 @@ import {
   FireFlyDeleteOptions,
   FireFlyTokenApprovalFilter,
   FireFlyTokenApprovalResponse,
+  FireFlyWebSocketConnectCallback,
 } from './interfaces';
 import { FireFlyWebSocket, FireFlyWebSocketCallback } from './websocket';
 import HttpBase, { mapConfig } from './http';
@@ -598,6 +599,7 @@ export default class FireFly extends HttpBase {
     subscriptions: string | string[] | FireFlySubscriptionBase,
     callback: FireFlyWebSocketCallback,
     socketOptions?: WebSocket.ClientOptions | http.ClientRequestArgs,
+    afterConnect?: FireFlyWebSocketConnectCallback,
   ): FireFlyWebSocket {
     const options: FireFlyWebSocketOptions = {
       host: this.options.websocket.host,
@@ -609,6 +611,7 @@ export default class FireFly extends HttpBase {
       reconnectDelay: this.options.websocket.reconnectDelay,
       heartbeatInterval: this.options.websocket.heartbeatInterval,
       socketOptions: socketOptions,
+      afterConnect: afterConnect,
     };
 
     const handler: FireFlyWebSocketCallback = (socket, event) => {

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -61,6 +61,14 @@ export interface FireFlyOptions extends FireFlyOptionsInput {
   };
 }
 
+export interface FireFlyWebSocketSender {
+  send: (json: JSON) => void;
+}
+
+export interface FireFlyWebSocketConnectCallback {
+  (sender: FireFlyWebSocketSender): void | Promise<void>;
+}
+
 export interface FireFlyWebSocketOptions {
   host: string;
   namespace: string;
@@ -72,6 +80,7 @@ export interface FireFlyWebSocketOptions {
   reconnectDelay: number;
   heartbeatInterval: number;
   socketOptions?: WebSocket.ClientOptions | http.ClientRequestArgs;
+  afterConnect?: FireFlyWebSocketConnectCallback;
 }
 
 // Namespace

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -83,6 +83,9 @@ export class FireFlyWebSocket {
           );
           this.logger.log(`Started listening on subscription ${this.options.namespace}:${name}`);
         }
+        if (this.options?.afterConnect !== undefined) {
+          this.options.afterConnect(this);
+        }
       })
       .on('error', (err) => {
         this.logger.error('Error', err.stack);
@@ -153,6 +156,12 @@ export class FireFlyWebSocket {
       } else {
         this.reconnectTimer = setTimeout(() => this.connect(), this.options.reconnectDelay);
       }
+    }
+  }
+
+  send(json: JSON) {
+    if (this.socket !== undefined) {
+      this.socket.send(JSON.stringify(json));
     }
   }
 

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -93,6 +93,7 @@ export class FireFlyWebSocket {
       .on('close', () => {
         if (this.closed) {
           this.logger.log('Closed');
+          this.closed(); // do this after all logging
         } else {
           this.disconnectDetected = true;
           this.reconnect('Closed by peer');


### PR DESCRIPTION
When using an ephemeral WebSocket to listen for completion of a FireFly action, you need to know the socket is connected before you submit the action. This isn't currently possible in the SDK.

It's also not possible to send custom commands over the WebSocket, or trigger other processing as a side-effect of a reconnect.

Also in unit tests in a framework like Jest, you cannot allow a test to write log statements after the test exits (see https://github.com/jestjs/jest/issues/9324#issuecomment-1396968497).

This drives a requirement for a `close()` function that allows us to await the logging of the close, which is also included as an option in this PR.