### PR TITLE
Add more helpers around subscriptions and batch delivery

### DIFF
--- a/lib/firefly.ts
+++ b/lib/firefly.ts
@@ -82,7 +82,7 @@ import {
   FireFlyDeployContractRequest,
   FireFlyDeployContractResponse,
   FireFlyWebSocketConnectCallback,
-  FireFlyGetOperationOptions,
+  FireFlyGetWithStatus,
 } from './interfaces';
 import { FireFlyWebSocket, FireFlyWebSocketCallback } from './websocket';
 import HttpBase, { mapConfig } from './http';
@@ -205,6 +205,13 @@ export default class FireFly extends HttpBase {
     options?: FireFlyGetOptions,
   ): Promise<FireFlySubscriptionResponse[]> {
     return this.getMany<FireFlySubscriptionResponse[]>('/subscriptions', filter, options);
+  }
+
+  getSubscription(
+    id: string,
+    options?: FireFlyGetWithStatus,
+  ): Promise<FireFlySubscriptionResponse | undefined> {
+    return this.getOne<FireFlySubscriptionResponse>(`/subscriptions/${id}`, options);
   }
 
   replaceSubscription(
@@ -572,7 +579,7 @@ export default class FireFly extends HttpBase {
 
   getOperation(
     id: string,
-    options?: FireFlyGetOperationOptions,
+    options?: FireFlyGetWithStatus,
   ): Promise<FireFlyOperationResponse | undefined> {
     const params = { fetchstatus: options?.fetchstatus };
     return this.getOne<FireFlyOperationResponse>(`/operations/${id}`, options, params);

--- a/lib/firefly.ts
+++ b/lib/firefly.ts
@@ -230,7 +230,7 @@ export default class FireFly extends HttpBase {
   }
 
   findData(
-    filter?: FireFlyDataFilter,
+    filter?: FireFlyDataFilter | URLSearchParams,
     options?: FireFlyGetOptions,
   ): Promise<FireFlyDataResponse[]> {
     return this.getMany<FireFlyDataResponse[]>(`/data`, filter, options);

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -9,6 +9,7 @@ import {
   FireFlyUpdateOptions,
   FireFlyDeleteOptions,
   FireFlyIdempotencyError,
+  FireFlyGetWithStatus,
 } from './interfaces';
 
 function isSuccess(status: number) {
@@ -18,6 +19,7 @@ function isSuccess(status: number) {
 export function mapConfig(
   options:
     | FireFlyGetOptions
+    | FireFlyGetWithStatus
     | FireFlyUpdateOptions
     | FireFlyReplaceOptions
     | FireFlyCreateOptions
@@ -29,6 +31,7 @@ export function mapConfig(
     ...options?.requestConfig,
     params,
   };
+
   if (options !== undefined) {
     if ('confirm' in options) {
       config.params = {
@@ -40,6 +43,12 @@ export function mapConfig(
       config.params = {
         ...config.params,
         publish: options.publish,
+      };
+    }
+    if ('fetchstatus' in options) {
+      config.params = {
+        ...config.params,
+        fetchstatus: options.fetchstatus,
       };
     }
   }

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -37,6 +37,10 @@ export interface FireFlyCreateOptions extends FireFlyBaseHttpOptions {
   publish?: boolean;
 }
 
+export interface FireFlyGetWithStatus extends FireFlyGetOptions {
+  fetchstatus?: string;
+}
+
 export interface FireFlyOptionsInput {
   host: string;
   namespace?: string;
@@ -129,7 +133,7 @@ export type FireFlySubscriptionRequest =
 
 export type FireFlySubscriptionResponse = Required<
   operations['getSubscriptionByID']['responses']['200']['content']['application/json']
->;
+> & { status?: any };
 export type FireFlyEventResponse = Required<
   operations['getEventByID']['responses']['200']['content']['application/json']
 >;
@@ -281,10 +285,6 @@ const approvals: ApprovalsList = [];
 export type FireFlyTokenApprovalResponse = typeof approvals[0];
 
 // Operations + Transactions
-
-export interface FireFlyGetOperationOptions extends FireFlyGetOptions {
-  fetchstatus?: string;
-}
 
 export type FireFlyOperationFilter = operations['getOps']['parameters']['query'];
 export type FireFlyTransactionFilter = operations['getTxns']['parameters']['query'];

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -185,6 +185,17 @@ export interface FireFlyEventDelivery extends Omit<FireFlyEnrichedEvent, 'type'>
   };
 }
 
+export interface FireFlyEventBatchDelivery {
+  type: 'event_batch';
+  id: string;
+  subscription: {
+    id: string;
+    name: string;
+    namespace: string;
+  };
+  events: FireFlyEventDelivery[];
+}
+
 // Datatypes
 
 export type FireFlyDatatypeFilter = operations['getDatatypes']['parameters']['query'];

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -5,6 +5,7 @@ import {
   FireFlyEphemeralSubscription,
   FireFlyWebSocketOptions,
   FireFlyEventDelivery,
+  FireFlyEventBatchDelivery,
 } from './interfaces';
 import Logger from './logger';
 
@@ -19,7 +20,10 @@ function buildEphemeralQueryParams(sub: FireFlyEphemeralSubscription) {
 }
 
 export interface FireFlyWebSocketCallback {
-  (socket: FireFlyWebSocket, data: FireFlyEventDelivery): void | Promise<void>;
+  (
+    socket: FireFlyWebSocket,
+    data: FireFlyEventDelivery | FireFlyEventBatchDelivery,
+  ): void | Promise<void>;
 }
 
 export class FireFlyWebSocket {
@@ -166,7 +170,7 @@ export class FireFlyWebSocket {
     }
   }
 
-  ack(event: FireFlyEventDelivery) {
+  ack(event: FireFlyEventDelivery | FireFlyEventBatchDelivery) {
     if (this.socket !== undefined && event.id !== undefined) {
       this.socket.send(
         JSON.stringify({
@@ -179,7 +183,7 @@ export class FireFlyWebSocket {
   }
 
   async close(wait?: boolean): Promise<void> {
-    const closedPromise = new Promise<void>(resolve => {
+    const closedPromise = new Promise<void>((resolve) => {
       this.closed = resolve;
     });
     this.clearPingTimers();


### PR DESCRIPTION
Mainline version of FireFly now supports batch delivery of events over websockets: https://github.com/hyperledger/firefly/pull/1447
This PR adds support for consuming batched events, and adds a related option for calling "findData" to fetch all data related to a batch of messages.

Also adds a missing `getSubscription` API (not a new feature, just missing).