### PR TITLE
Update package version to 1.3.0-alpha.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.2.16",
+  "version": "1.3.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperledger/firefly-sdk",
-      "version": "1.2.16",
+      "version": "1.3.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/firefly-sdk",
-  "version": "1.2.16",
+  "version": "1.3.0-alpha.1",
   "description": "Client SDK for Hyperledger FireFly",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Follow-on to https://github.com/hyperledger/firefly-sdk-nodejs/pull/85#pullrequestreview-1860025716 - will perform mainline releases with an "alpha" suffix now that some non-released functionality of FireFly is integrated.

Note - I also pulled a `release-1.2` branch from the last 1.2 release, so that we can easily release additional functions there if needed.